### PR TITLE
docs: replace README with operator manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,128 @@
-# sol-atomic-launcher (plan-first)
+# Raydium Init Bot — Atomic Launcher
 
-Goal: Accept a plan JSON and orchestrate a token launch (funding → mint → metadata → Raydium v4 initialize2 → buys).
-This patch focuses only on schema compatibility + CLI dry-run.
+End-to-end permissionless token launch workflow driven by a JSON “plan”.
+From one Seed keypair it funds wallets, mints tokens, creates metadata,
+initializes a Raydium v4 pool, and executes buys — all idempotent,
+resumable, and receipt-tracked.
 
-## Quick start
+---
 
-```bash
+## 1. Requirements
+
+Ubuntu 20.04+ or Debian-based system.
+
+Install system deps:
+sudo apt update
+sudo apt install -y python3 python3-venv python3-pip git
+
+Clone repo:
+git clone https://github.com/<YOUR_REPO>/raydium-init-bot.git
+cd raydium-init-bot
+
+Set up venv:
 python3 -m venv venv
-. venv/bin/activate
+source venv/bin/activate
 pip install -r requirements.txt
 
-mkdir -p plans
-cp downstream_plan_mainnet-beta_10000000mint_16.00pctLP_1.0SOL_99pct_3buys.json plans/
+---
 
-python launcher.py --plan plans/downstream_plan_mainnet-beta_10000000mint_16.00pctLP_1.0SOL_99pct_3buys.json --dry-run
-```
-## Execution scaffold (no chain ops yet)
+## 2. Config & Secrets
 
-This patch adds a resumable orchestrator that produces receipts for each step. It does **not** submit transactions yet.
+1. Wallet passphrase for encrypted subwallets:
+export LAUNCHER_WALLET_PASS="choose-a-strong-passphrase"
 
-Run end-to-end scaffold:
+2. Seed keypair file (JSON array of 64 ints). Place under:
+keys/seed.json
 
-```bash
-python launcher.py \
-  --plan plans/downstream_plan_mainnet-beta_10000000mint_16.00pctLP_1.0SOL_99pct_3buys.json \
-  --out state
-```
-## Hardening & Resumability
+3. Config YAML: see configs/defaults.yaml. It must contain:
+program_ids:
+  metaplex_token_metadata: <MPL_PROGRAM_ID>
+  raydium_v4_amm: <RAYDIUM_PROGRAM_ID>
+mints:
+  wrapped_sol: So11111111111111111111111111111111111111112
+fees:
+  compute_unit_limit: 1000000
+  compute_unit_price_micro_lamports: 150000
 
-This patch:
-- Adds package `__init__.py` files,
-- Persists `artifacts.json` across steps,
-- Versioned receipts with `schema_version`, `plan_hash`, `created_ms`,
-- Saves a copy of the executed plan to `state/plan.json`,
-- Loads config from `configs/defaults.yaml`,
-- Implements true resume: steps are skipped when their receipt exists and artifacts contain required fields.
+---
 
-Run:
-```bash
-python launcher.py --plan plans/downstream_plan_mainnet-beta_10000000mint_16.00pctLP_1.0SOL_99pct_3buys.json --out state
-```
+## 3. Plan
 
-## Hardened scaffold (no chain ops yet)
+Place your plan JSON under plans/.
+Example: plans/downstream_plan_mainnet-beta.json
 
-- Packages have proper `__init__.py`
-- `artifacts.json` persists mint/pool/swaps placeholders
-- Receipts include `schema_version`, `plan_hash`, `created_ms`
-- `configs/defaults.yaml` is loaded; key program IDs are displayed
-- `--only lp` normalized to `lp_init`
+---
 
-Run full scaffold:
-```bash
-python launcher.py \
-  --plan plans/downstream_plan_mainnet-beta_10000000mint_16.00pctLP_1.0SOL_99pct_3buys.json \
-  --out state
-```
+## 4. Quick Commands
 
-## Production Runbook (mainnet-beta, prod-safe)
+4.1 Dry summary (no network)
+python launcher.py run --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --dry-run
 
-1) Prepare:
-   - `export LAUNCHER_WALLET_PASS="your-strong-passphrase"`
-   - Place your plan JSON under `./plans/`.
-   - Ensure RPC URL is mainnet-beta and healthy.
+4.2 Preflight (simulate, no submit)
+python launcher.py preflight --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --strict
+Exits code 0 if all checks/simulations OK, else 1.
 
-2) Dry summary:
-```bash
-python launcher.py --plan plans/<PLAN>.json --rpc https://YOUR_RPC --simulate --only mint --out state
-```
+4.3 Full run (all steps, resumable)
+python launcher.py run --plan plans/downstream_plan_mainnet-beta.json --seed-keypair keys/seed.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --priority-fee 150000 --cu-limit 1000000
+
+4.4 Resume run (skip finished steps)
+python launcher.py run --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --resume
+
+4.5 Limit buys (testing safety)
+python launcher.py run --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --max-buys 2
+
+4.6 Verify after run (read-only checks)
+python launcher.py verify --out state --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml
+Exits code 0 if mint, metadata PDA, and pool exist; else 1.
+
+---
+
+## 5. Outputs
+
+- Receipts: state/receipts/*.json (one per step)
+- Artifacts: state/artifacts.json (merged state)
+- Telemetry: state/telemetry.ndjson (append-only events)
+- Encrypted wallets: state/wallets/*.enc
+
+---
+
+## 6. Safety Features
+
+- Idempotency: steps skip if already done on-chain
+- Resume: re-run with --resume to continue after interruption
+- Per-wallet swap guards: no duplicate buys
+- Runtime bounds: decimals 0–9; slippage ≤ 5000 bps; positive LP tokens
+- Exit codes: preflight --strict and verify exit non-zero if checks fail
+- Max buys: optional --max-buys N cap for test runs
+
+---
+
+## 7. Test Ladder
+
+1. Offline unit tests:
+pytest -q
+
+2. Preflight (safe):
+python launcher.py preflight --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --strict
+
+3. Controlled run (limit buys):
+python launcher.py run --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --max-buys 1
+
+4. Resume run:
+python launcher.py run --plan plans/downstream_plan_mainnet-beta.json --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml --out state --resume
+
+5. Verify after run:
+python launcher.py verify --out state --rpc https://api.mainnet-beta.solana.com --config configs/defaults.yaml
+
+---
+
+## 8. Notes
+
+- Do not commit or log seed keypairs
+- Use a private RPC with sufficient CU budget support
+- Always preflight before a live run
+
+---
+
+End of README.md replacement.
+


### PR DESCRIPTION
## Summary
- Replace README with a concise operator manual
- Document requirements, config setup, plan files, quick commands, outputs, safety and test ladder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6d9e72e0c832bb0e189951feffc6a