### PR TITLE
Pin construct 2.10.68 and add typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-# === Core Solana stack (mutually compatible with PyPI) ===
+# === Core Solana stack (mutually compatible) ===
 solana==0.36.9
 solders==0.26.0
-construct==2.10.70
+construct==2.10.68
 construct-typing==0.6.2
 base58==2.1.1
 
@@ -31,6 +31,7 @@ pydantic==2.8.2
 orjson==3.10.7
 python-dotenv==1.0.1
 PyYAML==6.0.2
+typing-extensions==4.15.0
 
 # === Logging / CLI ===
 structlog==24.4.0


### PR DESCRIPTION
## Summary
- align `construct` version with `construct-typing` by pinning 2.10.68
- add missing `typing-extensions` requirement for Python 3.12 compatibility

## Testing
- `python3 -m venv venv`
- `pip install --upgrade pip setuptools wheel` (fails: Tunnel connection failed: 403 Forbidden)
- `pip install -r requirements.txt` (fails: Tunnel connection failed: 403 Forbidden)
- `python - <<'PY' ...` (fails: ModuleNotFoundError: No module named 'solana')


------
https://chatgpt.com/codex/tasks/task_e_68b701f96690832b941ce8c748165e29